### PR TITLE
feat: use own socket for client, input objects, return socket on sever

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ RocketRPC is typesafe RPC library which gets out of your way. Define methods in 
 
 ## Usage
 
-
-
 https://user-images.githubusercontent.com/22196279/218526614-2b971301-0a72-4092-88d0-e47a8f29e3b6.mp4
-
-
 
 ### Installation
 
@@ -35,7 +31,7 @@ const { listFiles, prisma } = client;
 const main = async () => {
   // use prisma on the client
   console.log(await prisma.user.findMany());
-  
+
   // passing multiple parameters to the function
   console.log(await client.sum(12, 20));
 
@@ -57,7 +53,7 @@ import listFiles from "./apis/listFiles";
 const api = {
   // initialize Prisma once
   prisma: new PrismaClient();
-  
+
   sum: (x: number, y: number) => x + y,
 
   // Fetch all files on server
@@ -66,7 +62,10 @@ const api = {
 
 export type API = typeof api;
 
-Server(8080, api);
+Server({
+  server: 8080,
+  api
+});
 ```
 
 ## Error Handling
@@ -127,4 +126,3 @@ The client function is actually a generic, which accepts the type provided by th
 Pull requests are welcome. You'll probably find lots of improvements to be made.
 
 Open issues for feedback, requesting features, reporting bugs or discussing ideas.
-

--- a/examples/basic/server/index.ts
+++ b/examples/basic/server/index.ts
@@ -13,4 +13,7 @@ const api: API = {
   errorFunction: (a: { b: unknown }) => a.b,
 };
 
-Server(8080, api);
+Server({
+  server: 8080,
+  api,
+});

--- a/examples/express/server.ts
+++ b/examples/express/server.ts
@@ -24,6 +24,6 @@ const api = {
 export type API = typeof api;
 
 Server({
-  srv: server,
+  server,
   api,
 });

--- a/examples/express/server.ts
+++ b/examples/express/server.ts
@@ -23,4 +23,7 @@ const api = {
 
 export type API = typeof api;
 
-Server(server, api);
+Server({
+  srv: server,
+  api,
+});

--- a/examples/prisma-example/server/index.ts
+++ b/examples/prisma-example/server/index.ts
@@ -1,4 +1,7 @@
 import { Server } from "../../../src/index";
 import { api } from "./api";
 
-Server(8080, api);
+Server({
+  server: 8080,
+  api,
+});

--- a/examples/react/server/index.ts
+++ b/examples/react/server/index.ts
@@ -10,10 +10,14 @@ const api = {
 
 export type API = typeof api;
 
-Server(8080, api, {
-  serverOptions: {
-    cors: {
-      origin: "*",
+Server({
+  server: 8080,
+  api,
+  meta: {
+    serverOptions: {
+      cors: {
+        origin: "*",
+      },
     },
   },
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -17,10 +17,21 @@ type PromisifyRecord<T> = {
     : never;
 } & { _rocketRpcContext: { socket: Socket } };
 
+export interface ClientInput {
+  // Socket.io endpoint default 8080
+  endpoint?: string;
+  // Use your own socket.io socket
+  socket?: Socket;
+}
+
 export default function Client<
   API extends Record<string | symbol | number, unknown>
->(endpoint: string = "http://localhost:8080") {
-  const socket = io(endpoint);
+>(input: ClientInput = {}): PromisifyRecord<API> {
+  let socket: Socket | undefined = input.socket;
+  if (!socket) {
+    const endpoint = input.endpoint || "http://localhost:8080";
+    socket = io(endpoint);
+  }
 
   const queue: { [key: string]: (value: unknown) => void } = {};
 
@@ -67,7 +78,7 @@ export default function Client<
             params: argumentsList,
           };
 
-          socket.emit("function-call", functionCallParams);
+          socket?.emit("function-call", functionCallParams);
 
           return new Promise((resolve) => waitForResult(id, resolve));
         },

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,20 +1,48 @@
+import { io, Socket } from "socket.io-client";
 import Client from "../src/client/index";
+import crypto from "crypto";
 
-describe("client context returns socket object", () => {
-  let client: ReturnType<typeof Client>;
+describe("client", () => {
+  describe("default socket", () => {
+    let client: ReturnType<typeof Client>;
 
-  beforeAll(() => {
-    client = Client();
+    beforeAll(() => {
+      client = Client();
+    });
+
+    afterAll(() => {
+      client._rocketRpcContext.socket.close();
+    });
+
+    test("should return the instance of socket", () => {
+      const socket = client._rocketRpcContext.socket;
+
+      expect(client.socket).toEqual({});
+      expect(socket.constructor.name).toEqual("Socket");
+    });
   });
 
-  afterAll(() => {
-    client._rocketRpcContext.socket.close();
-  });
+  describe("custom socket", () => {
+    let socket: Socket;
 
-  test("should return the instance of socket", () => {
-    const socket = client._rocketRpcContext.socket;
+    beforeAll(() => {
+      socket = io("http://localhost:3000");
+    });
 
-    expect(client.socket).toEqual({});
-    expect(socket.constructor.name).toEqual("Socket");
+    afterAll(() => {
+      socket.close();
+    });
+
+    test("should return the provided socket instance", async () => {
+      const testValue = crypto.randomBytes(20).toString("hex");
+
+      // @ts-ignore
+      socket[testValue] = testValue;
+
+      const client = Client({ socket });
+
+      // @ts-ignore
+      expect(client._rocketRpcContext.socket[testValue]).toEqual(testValue);
+    });
   });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,42 @@
+import Server from "../src/server/index";
+
+describe("server", () => {
+  describe("validation", () => {
+    test("should throw an error if no server is provided", () => {
+      // @ts-ignore
+      expect(() => Server({})).toThrowError(
+        "RocketRPC Server Error: No server provided"
+      );
+    });
+
+    test("should throw an error if no api is provided", () => {
+      expect(() =>
+        // @ts-ignore
+        Server({
+          server: 3000,
+        })
+      ).toThrowError("RocketRPC Server Error: No API provided");
+    });
+  });
+
+  describe("default socket", () => {
+    let server: ReturnType<typeof Server>;
+
+    beforeAll(() => {
+      server = Server({
+        server: 3000,
+        api: {},
+      });
+    });
+
+    afterAll(() => {
+      server._rocketRpcContext.socket.close();
+    });
+
+    test("should return the instance of socket server", () => {
+      const socket = server._rocketRpcContext.socket;
+
+      expect(socket.constructor.name).toEqual("Server");
+    });
+  });
+});


### PR DESCRIPTION
This PR allows clients to use their own socket instance - this could be handy for testing, authentication, and stubbing.

I have changed the `Server` and `Client` functions to now accept an `input` arg. I think this will scale better than ordered function parameters.

Finally, I have returned the server instance from the `Server` function. 